### PR TITLE
Exclude routes based on patterns containing wildcards (`*`)

### DIFF
--- a/src/RouteTesting.php
+++ b/src/RouteTesting.php
@@ -88,12 +88,11 @@ class RouteTesting
     protected function isExcluded(string $name): bool
     {
         foreach ($this->excludedRoutes as $excludedRoute) {
-            $pattern = str_replace('\*', '.*', preg_quote($excludedRoute, '/'));
-
-            if (preg_match('/^' . $pattern . '$/', $name)) {
+            if(Str::is($excludedRoute, $name)) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/tests/RouteTestingTest.php
+++ b/tests/RouteTestingTest.php
@@ -94,6 +94,20 @@ it('can exclude routes based on a wildcard', function () {
         ->toHaveKey('get-endpoint');
 });
 
+it('can exclude routes based on a wildcard 2', function () {
+    Route::get('api/posts', fn () => '');
+    Route::get('api/posts/comments', fn () => '');
+    Route::get('api/comments', fn () => '');
+
+    $class = routeTesting()
+        ->excluding(['api/comments/*'])
+        ->toReturnSuccessfulResponse();
+
+    expect($class->assertedRoutes)
+        ->toHaveCount(1)
+        ->toHaveKey('api/comments');
+});
+
 it('ignores some routes by default', function () {
     Route::get('/_ignition', fn () => '');
     Route::get('/_debugbar', fn () => '');

--- a/tests/RouteTestingTest.php
+++ b/tests/RouteTestingTest.php
@@ -7,8 +7,8 @@ use Tests\TestClasses\TestUser;
 use function Spatie\RouteTesting\routeTesting;
 
 it('only checks for GET endpoints', function () {
-    Route::get('/get-endpoint', fn () => '');
-    Route::post('/post-endpoint', fn () => '');
+    Route::get('/get-endpoint', fn() => '');
+    Route::post('/post-endpoint', fn() => '');
 
     $class = routeTesting()->toReturnSuccessfulResponse();
 
@@ -21,7 +21,7 @@ it('only checks for GET endpoints', function () {
 });
 
 it('can bind a model to a route', function () {
-    Route::get('{user}', fn () => '');
+    Route::get('{user}', fn() => '');
 
     $model = new TestModel();
 
@@ -41,7 +41,7 @@ it('can bind a model to a route', function () {
 });
 
 it('can exclude routes with unknown bindings', function () {
-    Route::get('{user}', fn () => '');
+    Route::get('{user}', fn() => '');
 
     $class = routeTesting()->toReturnSuccessfulResponse();
 
@@ -54,8 +54,8 @@ it('can exclude routes with unknown bindings', function () {
 });
 
 it('can exclude routes', function () {
-    Route::get('/get-endpoint', fn () => '');
-    Route::get('/excluded-endpoint', fn () => '');
+    Route::get('/get-endpoint', fn() => '');
+    Route::get('/excluded-endpoint', fn() => '');
 
     $class = routeTesting()
         ->excluding(['excluded-endpoint'])
@@ -67,9 +67,9 @@ it('can exclude routes', function () {
 });
 
 it('can exclude multiple routes', function () {
-    Route::get('/get-endpoint', fn () => '');
-    Route::get('/excluded-endpoint', fn () => '');
-    Route::get('/2-excluded-endpoint', fn () => '');
+    Route::get('/get-endpoint', fn() => '');
+    Route::get('/excluded-endpoint', fn() => '');
+    Route::get('/2-excluded-endpoint', fn() => '');
 
     $class = routeTesting()
         ->excluding(['excluded-endpoint', '2-excluded-endpoint'])
@@ -81,9 +81,9 @@ it('can exclude multiple routes', function () {
 });
 
 it('can exclude routes based on a wildcard', function () {
-    Route::get('/get-endpoint', fn () => '');
-    Route::get('/excluded-endpoint', fn () => '');
-    Route::get('/excluded-endpoint-2', fn () => '');
+    Route::get('/get-endpoint', fn() => '');
+    Route::get('/excluded-endpoint', fn() => '');
+    Route::get('/excluded-endpoint-2', fn() => '');
 
     $class = routeTesting()
         ->excluding(['excluded-*'])
@@ -95,12 +95,12 @@ it('can exclude routes based on a wildcard', function () {
 });
 
 it('can exclude routes based on a wildcard 2', function () {
-    Route::get('api/posts', fn () => '');
-    Route::get('api/posts/comments', fn () => '');
-    Route::get('api/comments', fn () => '');
+    Route::get('api/posts', fn() => '');
+    Route::get('api/posts/comments', fn() => '');
+    Route::get('api/comments', fn() => '');
 
     $class = routeTesting()
-        ->excluding(['api/comments/*'])
+        ->excluding(['api/posts*'])
         ->toReturnSuccessfulResponse();
 
     expect($class->assertedRoutes)
@@ -108,9 +108,38 @@ it('can exclude routes based on a wildcard 2', function () {
         ->toHaveKey('api/comments');
 });
 
+it('can exclude routes based on a wildcard 3', function () {
+    Route::get('api/posts', fn() => '');
+    Route::get('api/posts/comments', fn() => '');
+    Route::get('api/comments', fn() => '');
+
+    $class = routeTesting()
+        ->excluding(['api/*/comments'])
+        ->toReturnSuccessfulResponse();
+
+    expect($class->assertedRoutes)
+        ->toHaveCount(2)
+        ->toHaveKey('api/comments')
+        ->toHaveKey('api/posts');
+});
+
+it('can exclude routes based on a wildcard 4', function () {
+    Route::get('api/posts', fn() => '');
+    Route::get('api/posts/comments', fn() => '');
+    Route::get('api/comments', fn() => '');
+
+    $class = routeTesting()
+        ->excluding(['*/comments'])
+        ->toReturnSuccessfulResponse();
+
+    expect($class->assertedRoutes)
+        ->toHaveCount(1)
+        ->toHaveKey('api/posts');
+});
+
 it('ignores some routes by default', function () {
-    Route::get('/_ignition', fn () => '');
-    Route::get('/_debugbar', fn () => '');
+    Route::get('/_ignition', fn() => '');
+    Route::get('/_debugbar', fn() => '');
 
     $class = routeTesting()->toReturnSuccessfulResponse();
 
@@ -124,9 +153,9 @@ it('ignores some routes by default', function () {
 });
 
 it('can act as a user for authenticated routes', function () {
-    Route::middleware('auth')->get('/authenticated-endpoint', fn () => '');
+    Route::middleware('auth')->get('/authenticated-endpoint', fn() => '');
 
-    expect(fn () => routeTesting()->toReturnSuccessfulResponse())
+    expect(fn() => routeTesting()->toReturnSuccessfulResponse())
         ->toThrow(\Illuminate\Http\Exceptions\HttpResponseException::class);
 
     test()->actingAs(new TestUser());


### PR DESCRIPTION
Uses Laravel's [`Str::is()`](https://laravel.com/docs/master/strings#method-str-is) to match excluded routes and adds some extra tests.