### PR TITLE
Exclude all _debugbar routes

### DIFF
--- a/src/RouteTestingTestCall.php
+++ b/src/RouteTestingTestCall.php
@@ -33,7 +33,7 @@ class RouteTestingTestCall
 
         $this->exclude([
             '_ignition',
-            '_debugbar',
+            '_debugbar*',
             'horizon*',
             'pulse*',
             'sanctum*',


### PR DESCRIPTION
Excludes all debugbar routes, including:
```
_debugbar/assets/javascript
_debugbar/assets/stylesheets
_debugbar/clockwork/{id}
_debugbar/open
```