### PR TITLE
Upgrade for PEST v3.0

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -31,16 +31,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "nunomaduro/termwind": "^1.15.1|^2.0",
-        "pestphp/pest": "^2.34.9",
-        "pestphp/pest-plugin": "^2.1.1",
-        "spatie/laravel-package-tools": "^1.16.4"
+        "php": "^8.2",
+        "nunomaduro/termwind": "^1.15.1|^2.1",
+        "pestphp/pest": "^3.0.6",
+        "pestphp/pest-plugin": "^3.0",
+        "spatie/laravel-package-tools": "^1.16.5"
     },
     "require-dev": {
-        "laravel/pint": "^1.16.2",
-        "orchestra/testbench": "^8.24",
-        "pestphp/pest-dev-tools": "^2.16"
+        "laravel/pint": "^1.17.3",
+        "orchestra/testbench": "^9.4",
+        "pestphp/pest-dev-tools": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,7 +6,7 @@ use Tests\TestCase;
 uses(TestCase::class)->in(__DIR__);
 
 expect()->extend('toContainRoutes', function (array $expectedRoutes) {
-    $routesNames = collect($this->value)->map(fn ($route) => $route['uri'])->toArray();
+    $routesNames = collect($this->value)->map(fn ($route) => $route['uri'])->values()->toArray();
 
     Assert::assertEqualsCanonicalizing($expectedRoutes, $routesNames);
 });


### PR DESCRIPTION
Here is a PR update the plugin for PEST **v3.0** and require PHP **^8.2**, related to #13 

- I fixed toContainRoutes custom expectation by adding `->values()` after `->map()`
- Maybe it should support PEST v2.0 and v3.0, not only v3.0 ?