### PR TITLE
Enable Pest expectations in route testing

### DIFF
--- a/src/RouteTestingTestCall.php
+++ b/src/RouteTestingTestCall.php
@@ -6,6 +6,8 @@ use Closure;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Testing\TestResponse;
+use Pest\Expectation;
+use Pest\Mixins\Expectation as ExpectationMixin;
 use Pest\PendingCalls\TestCall;
 
 /** @mixin TestResponse|TestCall */
@@ -111,7 +113,11 @@ class RouteTestingTestCall
     {
         // Assertions cannot be chained on the test call yet until the user is done adding bindings and other Pest test methods.
         // We'll capture assertions and apply them to the TestResponse later (in the __destruct method).
-        if (in_array($method, get_class_methods(TestResponse::class))) {
+        if (in_array($method, array_unique([
+            ...get_class_methods(TestResponse::class),
+            ...get_class_methods(Expectation::class),
+            ...get_class_methods(ExpectationMixin::class),
+        ]))) {
             $this->assertions[] = [$method, $parameters];
 
             return $this;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Pest\Matchers\Any;
 use PHPUnit\Framework\Assert;
 use Tests\TestCase;
 
@@ -9,4 +10,22 @@ expect()->extend('toContainRoutes', function (array $expectedRoutes) {
     $routesNames = collect($this->value)->map(fn ($route) => $route['uri'])->values()->toArray();
 
     Assert::assertEqualsCanonicalizing($expectedRoutes, $routesNames);
+});
+
+expect()->extend('toHaveProtectedProperty', function (string $name, mixed $value = new Any, string $message = '') {
+    $this->toBeObject();
+
+    Assert::assertTrue(property_exists($this->value, $name), $message);
+
+    $reflection = new ReflectionClass($this->value);
+    $property = $reflection->getProperty($name);
+    $property->setAccessible(true);
+
+    Assert::assertTrue($property->isProtected(), $message);
+
+    if (! $value instanceof Any) {
+        Assert::assertEquals($value, $property->getValue($this->value), $message);
+    }
+
+    return $this;
 });

--- a/tests/RouteTestingTestCallTest.php
+++ b/tests/RouteTestingTestCallTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Pest\PendingCalls\TestCall;
+use Pest\TestSuite;
+use Spatie\RouteTesting\RouteTestingTestCall;
+
+it('can use any assertion', function (string $assertion, array $expectedAssertions) {
+    $routeTestingTestCall = createRouteTestingTestCall();
+    $routeTestingTestCall->$assertion();
+
+    expect($routeTestingTestCall)->toHaveProtectedProperty('assertions', $expectedAssertions);
+})->with([
+    'assertion' => ['assertSuccessful', [['assertSuccessful', []]]],
+    'expectation' => ['toMatch', [['toMatch', []]]],
+    'expectation mixin' => ['toMatchSnapshot', [['toMatchSnapshot', []]]],
+    'nonexsitent assertion' => ['nonexistentAssertion', []],
+]);
+
+function createRouteTestingTestCall(): RouteTestingTestCall
+{
+    $testSuite = new TestSuite('', '');
+    $testCall = new TestCall($testSuite, '');
+
+    return new RouteTestingTestCall($testCall);
+}


### PR DESCRIPTION
I think it would be useful if this plugin could be used in combination with Pest's snapshot testing (`toMatchSnapshot()`).