### PR TITLE
Fix Unknown named parameter $method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,7 +31,7 @@ parameters:
 			path: src/RouteResolver.php
 
 		-
-			message: "#^Method Spatie\\\\RouteTesting\\\\RouteResolver\\:\\:getFilteredRouteList\\(\\) should return array\\<int, array\\{method\\: string, uri\\: string\\}\\> but returns array\\<int, mixed\\>\\.$#"
+			message: "#^Method Spatie\\\\RouteTesting\\\\RouteResolver\\:\\:getFilteredRouteList\\(\\) should return array\\<int, array\\<int, string\\>\\> but returns array\\<int, mixed\\>\\.$#"
 			count: 1
 			path: src/RouteResolver.php
 
@@ -66,17 +66,22 @@ parameters:
 			path: src/RouteResolver.php
 
 		-
+			message: "#^Call to an undefined method Illuminate\\\\Contracts\\\\Routing\\\\UrlGenerator\\:\\:toRoute\\(\\)\\.$#"
+			count: 1
+			path: src/RouteTest.php
+
+		-
 			message: "#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\:\\:defer\\(\\)\\.$#"
 			count: 1
 			path: src/RouteTest.php
 
 		-
-			message: "#^Cannot call method toRoute\\(\\) on Illuminate\\\\Contracts\\\\Routing\\\\UrlGenerator\\|string\\.$#"
+			message: "#^Method Spatie\\\\RouteTesting\\\\RouteTest\\:\\:test\\(\\) has parameter \\$assertions with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/RouteTest.php
 
 		-
-			message: "#^Method Spatie\\\\RouteTesting\\\\RouteTest\\:\\:test\\(\\) has parameter \\$assertions with no value type specified in iterable type array\\.$#"
+			message: "#^PHPDoc tag @var for variable \\$testResponse contains generic class Illuminate\\\\Testing\\\\TestResponse but does not specify its types\\: TResponse$#"
 			count: 1
 			path: src/RouteTest.php
 

--- a/src/RouteResolver.php
+++ b/src/RouteResolver.php
@@ -88,7 +88,7 @@ class RouteResolver
     }
 
     /**
-     * @return array<int, array{method: string, uri: string}>
+     * @return array<int, array<int, string>>
      */
     public function getFilteredRouteList(): array
     {
@@ -118,6 +118,7 @@ class RouteResolver
                     return count(array_diff($uriBindings, $this->bindingNames)) === 0;
                 });
             })
+            ->map(fn (array $route) => array_values($route))
             ->toArray();
     }
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,7 +7,7 @@ use Tests\TestCase;
 uses(TestCase::class)->in(__DIR__);
 
 expect()->extend('toContainRoutes', function (array $expectedRoutes) {
-    $routesNames = collect($this->value)->map(fn ($route) => $route['uri'])->values()->toArray();
+    $routesNames = collect($this->value)->map(fn ($route) => $route[1])->values()->toArray();
 
     Assert::assertEqualsCanonicalizing($expectedRoutes, $routesNames);
 });


### PR DESCRIPTION
Before this PR calling the `getFilteredRouteList()` method would return something like this:
```
[
    [
      "method" => "GET"
      "uri" => "login"
    ],
    [
      "method" => "GET"
      "uri" => "register"
    ]
]
```
Which resulted in `Unknown named parameter $method ` error but when you remove the `method` and `uri` keys, the dataset in tests is called correctly and the error disappears.
resolves #6