### PR TITLE
fix: test response macros not being applied in __call

### DIFF
--- a/src/RouteTestingTestCall.php
+++ b/src/RouteTestingTestCall.php
@@ -111,7 +111,7 @@ class RouteTestingTestCall
     {
         // Assertions cannot be chained on the test call yet until the user is done adding bindings and other Pest test methods.
         // We'll capture assertions and apply them to the TestResponse later (in the __destruct method).
-        if (in_array($method, get_class_methods(TestResponse::class)) || $method === 'toMatchSnapshot') {
+        if (in_array($method, get_class_methods(TestResponse::class)) || $method === 'toMatchSnapshot' || TestResponse::hasMacro($method)) {
             $this->assertions[] = [$method, $parameters];
 
             return $this;


### PR DESCRIPTION
hello, firstly thanks for the package, i needed to add macro to TestResponse class to test if route returns success or redirect codes. when i tried i noticed __call only forwards assertions to TestResposne only if methods are declared directly but does check for methods added via macro. 

thanks﻿
