### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 You can install the package via composer:
 
 ```bash
-composer require spatie/pest-plugin-route-testing
+composer require spatie/pest-plugin-route-testing --dev
 ```
 
 ## Usage


### PR DESCRIPTION
When you require the package without (--dev), like so: composer require spatie/pest-plugin-route-testing

You get the following message:
The package you required is recommended to be placed in require-dev (because it is tagged as "dev", "testing") but you did not use --dev. Do you want to re-run the command with --dev? [yes]?